### PR TITLE
Add Terraform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,39 @@
 /node_modules
 package-lock.json
 *.zip
+
+# Created by https://www.gitignore.io/api/terraform
+# Edit at https://www.gitignore.io/?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+tfplan
+
+# End of https://www.gitignore.io/api/terraform

--- a/infra/api.tf
+++ b/infra/api.tf
@@ -1,0 +1,30 @@
+resource "aws_apigatewayv2_api" "main" {
+  name          = local.resources_name
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  auto_deploy = true
+  name        = "$default"
+
+  // Workaround for
+  // https://github.com/terraform-providers/terraform-provider-aws/issues/12893
+  lifecycle {
+    ignore_changes = [deployment_id, default_route_settings]
+  }
+}
+
+resource "aws_apigatewayv2_integration" "main" {
+  api_id             = aws_apigatewayv2_api.main.id
+  connection_type    = "INTERNET"
+  integration_method = "POST"
+  integration_type   = "AWS_PROXY"
+  integration_uri    = aws_lambda_function.main.invoke_arn
+}
+
+resource "aws_apigatewayv2_route" "main" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.main.id}"
+}

--- a/infra/certificate.tf
+++ b/infra/certificate.tf
@@ -1,0 +1,4 @@
+data "aws_acm_certificate" "cert" {
+  domain = var.service_domain_name
+  count  = local.has_custom_domain ? 1 : 0
+}

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -1,0 +1,62 @@
+resource "aws_cloudfront_distribution" "main" {
+  is_ipv6_enabled = true
+  http_version    = "http2"
+
+  origin {
+    origin_id   = "origin-${local.resources_name}"
+    domain_name = aws_s3_bucket.main.website_endpoint
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+
+    custom_header {
+      name  = "User-Agent"
+      value = local.user_agent
+    }
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  aliases = local.has_custom_domain ? [var.service_domain_name] : []
+
+  default_cache_behavior {
+    target_origin_id = "origin-${local.resources_name}"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    compress         = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    // The default ttl is 0 because we don't want CloudFront the S3 -> Api
+    // Gateway redirect. To keep images cached, we specify a custom "max-age"
+    // value when storing the resized image in S3. CloudFront will respect that
+    // value.
+    default_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = local.has_custom_domain ? data.aws_acm_certificate.cert[0].arn : null
+    cloudfront_default_certificate = ! local.has_custom_domain
+    minimum_protocol_version       = "TLSv1"
+    ssl_support_method             = "sni-only"
+  }
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,99 @@
+resource "aws_lambda_function" "main" {
+  filename      = "s3-resizer_nodejs_12.13.0.zip"
+  function_name = local.lambda_name
+  handler       = "index.handler"
+  memory_size   = 768
+  role          = aws_iam_role.lambda_role.arn
+  runtime       = "nodejs12.x"
+  timeout       = 15
+
+  environment {
+    variables = {
+      SOURCE_BUCKET      = data.aws_s3_bucket.source.bucket
+      DESTINATION_BUCKET = aws_s3_bucket.main.bucket
+      URL                = local.has_custom_domain ? "https://${var.service_domain_name}" : "https://${aws_cloudfront_distribution.main.domain_name}"
+      WHITELIST          = var.size_whitelist
+    }
+  }
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.main.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*/*"
+  statement_id  = "AllowAPIGatewayInvoke"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+  name               = "${local.resources_name}.labmda_role"
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  policy = data.aws_iam_policy_document.lambda_permissions.json
+  name   = "${local.resources_name}.lambda_policy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  policy_arn = aws_iam_policy.lambda_policy.arn
+  role       = aws_iam_role.lambda_role.name
+}
+
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      identifiers = ["lambda.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lambda_permissions" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${data.aws_s3_bucket.source.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.main.bucket}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${data.aws_s3_bucket.source.bucket}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.main.bucket}/*",
+    ]
+  }
+}

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,0 +1,14 @@
+resource "random_id" "bucket" {
+  byte_length = 8
+}
+
+resource "random_password" "secret" {
+  length = 8
+}
+
+locals {
+  resources_name    = "s3-resizer.${random_id.bucket.hex}"
+  lambda_name       = "s3-resizer_${random_id.bucket.hex}"
+  user_agent        = base64sha512(random_password.secret.result)
+  has_custom_domain = var.service_domain_name != ""
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.12.25"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  version = "~> 2.64"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudfront_endpoint" {
+  value = aws_cloudfront_distribution.main.domain_name
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,56 @@
+data "aws_s3_bucket" "source" {
+  bucket = var.source_bucket
+}
+
+resource "aws_s3_bucket" "main" {
+  bucket = local.resources_name
+  acl    = "private"
+  policy = data.aws_iam_policy_document.bucket_policy.json
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+
+    routing_rules = jsonencode(
+      [
+        {
+          Condition = {
+            HttpErrorCodeReturnedEquals = "404"
+          }
+          Redirect = {
+            Protocol = "https"
+            HostName = replace(
+              aws_apigatewayv2_api.main.api_endpoint,
+              "https://",
+              ""
+            )
+            HttpRedirectCode = "307"
+          }
+        }
+      ]
+    )
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.resources_name}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:UserAgent"
+      values   = [local.user_agent]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,13 @@
+variable "source_bucket" {
+  description = "The source S3 bucket where the images are stored"
+}
+
+variable "service_domain_name" {
+  description = "The name of the subdomain where the service will be hosted. (i.e: img.example.com). If no subdomain is specified, the Cloudfront url will be used."
+  default     = ""
+}
+
+variable "size_whitelist" {
+  description = "A list of allowed size options, separated by spaces (e.g. AUTOx150 300x200 100x100_max). If no whitelist is specified, the lambda will process everything."
+  default     = ""
+}


### PR DESCRIPTION
This PR adds support for creating the entire infrastrcutre with [Terraform](https://www.terraform.io/). This is great for a number of reasons:

* It allows users to effortlessly provision the whole infrastructure, instead of having to replicate the tutorial step by step. It should help reduce the number of set up errors, and therefore reduce the developer time spent in providing support (i.e: reduce issues like #13)
* It enables contributors to have a consistent infrastructure. With manual provisioning, configuration errors can easily happen, whereas with [IaC](https://en.wikipedia.org/wiki/Infrastructure_as_code) forces everyone to have the same infrastructure, which will make development of `s3-resizer` easier. (i.e: reduce issues like #5 - if everyone has the same infra, everyone can "talk in the same language")

Take a look at the new `README.md` to see how everything works.

While developing this, I made two changes to how the whole flow works. These changes might warrant a new major version.

* Instead of having one bucket, now there are two buckts: the source and the destionation. The source bucket may be private, while the destination bucket must be public (through CloudFront, the public can not access it direcly).

    I made this change to make it easy for people to integrate `s3-resizer` with existing infrastructure. Otherwise, the current buckets would have to be imported into the terraform state, which is a bit more complicated.

    Furthermore, I think that this change is a nice security improvement: you can have the original, large files private, and only the resized files accessible to the public. This, in combination with the whitelist, can effectively protect the full-size files.

* The current guide reccommends to host the lambda from a custom route in a custom stage in an API Gateway, but I found using the `$default` route and stage to be more simple, because it removes the need for the `?path=` shenanigans. The cloudfront route is mapeed 1:1 to the lambda route.

    In consequence, I had to make some modifications to the `index.js` because now the `path` variable contains the leading slash.

Thanks for reading! If you have any questions I'll be happy to help :)